### PR TITLE
[Fix] RankBoard Scrollbar Move Correction

### DIFF
--- a/Assets/01.Scenes/InGameScene.unity
+++ b/Assets/01.Scenes/InGameScene.unity
@@ -362,11 +362,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4295893887863812, guid: 0041cb88ea7f5a74f8700b605cb94b8e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1383.0072
+      value: 1381.19
       objectReference: {fileID: 0}
     - target: {fileID: 4295893887863812, guid: 0041cb88ea7f5a74f8700b605cb94b8e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 647.675
+      value: 646.66
       objectReference: {fileID: 0}
     - target: {fileID: 4295893887863812, guid: 0041cb88ea7f5a74f8700b605cb94b8e, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2713,8 +2713,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 7.619223, y: 1.991878, z: 3.6084049}
-  m_Center: {x: 0.021846557, y: -0.14289927, z: 0.053792126}
+  m_Size: {x: 7.6192236, y: 1.991878, z: 1.9856484}
+  m_Center: {x: 0.02184641, y: -0.14289927, z: 0.8651706}
 --- !u!4 &439044992 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4705531507725027604, guid: 7954e20783c38154bbc862fd20987817, type: 3}
@@ -8893,7 +8893,7 @@ MonoBehaviour:
   m_text: Restart
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 7712318436022515578, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -10228,7 +10228,7 @@ MonoBehaviour:
   m_text: Exit
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 7712318436022515578, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -10501,7 +10501,7 @@ MonoBehaviour:
   m_text: Game Over
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 7712318436022515578, guid: 181b15a02199dfa4e9f8835cb0c3d2f6, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/02.Scripts/Object Controller/ScrollbarController.cs
+++ b/Assets/02.Scripts/Object Controller/ScrollbarController.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ScrollbarController : MonoBehaviour
+{
+    [SerializeField] Scrollbar scrollbar;
+    int minScrollValue = -160;  // 스크롤바의 최소이동 거리
+    int maxScrollValue = 2;     // 스크롤바의 최대이동 거리
+
+    private void FixedUpdate()
+    {
+        if(scrollbar.value >= maxScrollValue)   // 스크롤바의 최대이동 거리 제약
+        {
+            scrollbar.value = maxScrollValue;
+        }
+        else if (scrollbar.value <= minScrollValue)     // 스크롤바의 최소이동 거리 제약
+        {
+            scrollbar.value = minScrollValue;
+        }
+    }
+}

--- a/Assets/02.Scripts/Object Controller/ScrollbarController.cs.meta
+++ b/Assets/02.Scripts/Object Controller/ScrollbarController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7136e07d488adf94695b0b0764d65f91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
랭크보드 스크롤바의 움직임이 랭킹데이터의 영역를 벗어나는 현상으로 스크롤 이동거리 리미트 추가